### PR TITLE
Adding missing Ninject.dll to deploy

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -8,6 +8,7 @@ copy src\WikiUpload\bin\release\WikiUp.exe.config Deploy\.
 copy src\WikiUpload\bin\release\Microsoft.Windows.Shell.dll Deploy\.
 copy src\WikiUpload\bin\release\MahApps.Metro.IconPacks.Core.dll Deploy\.
 copy src\WikiUpload\bin\release\MahApps.Metro.IconPacks.FontAwesome.dll Deploy\.
+copy src\WikiUpload\bin\release\Ninject.dll Deploy\.
 copy src\WikiUpload\bin\release\ToggleSwitch.dll Deploy\.
 goto :eof
 


### PR DESCRIPTION
The [released version](https://github.com/Aspallar/Wiki-Up/releases/tag/v1.8.0) crashes for me on Windows 7 SP1. Opening `WikiUp.exe` with VS debugger reveals the cause:

```
FileNotFoundException: Could not load the file or assembly 'Ninject, Version=3.3.4.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7' or one of its dependencies.
```

When building from source, Ninject.dll is correctly generated, but [deploy.cmd](https://github.com/Aspallar/Wiki-Up/blob/master/deploy.cmd) doesn't copy it to the Deploy directory. This PR just modifies the script to copy the missing assembly.