### PR TITLE
Use SystemDefault for ServicePointManager.SecurityProtocol

### DIFF
--- a/src/WikiUpload/App.xaml.cs
+++ b/src/WikiUpload/App.xaml.cs
@@ -35,7 +35,6 @@ namespace WikiUpload
             base.OnStartup(e);
 
             ServicePointManager.Expect100Continue = true;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
             GetCommandLineArguments(e.Args, out var timeout);
             Timewout = timeout;


### PR DESCRIPTION
Fixes #44 for Windows 11